### PR TITLE
Fixed bug in checking length of last CSF. Added gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore compiled libraries and executables
+*.o
+*.mod
+*.x
+*.il
+*.a

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                              #
 ################################################
 
-#FC = gfortran 
-#FFLAGS = -fbounds-check -fopenmp 
-FC = ifort
-FFLAGS = -check bounds -openmp
+FC = gfortran 
+FFLAGS = -fbounds-check -fopenmp 
+#FC = ifort
+#FFLAGS = -check bounds -openmp
 SRCS = csf2det.F90
 OBJS = csf2det.o
 EXEC = csf2det.x

--- a/csf2det.F90
+++ b/csf2det.F90
@@ -259,11 +259,11 @@
    ! compute the norm of the csf wfn for diagnostic purposes
    csf_norm = csf_norm + csf_cf(icsf)**2
 
-   ! if the returned coefficient is zero, we've read all csfs less than cutoff
-   if (icsf == n_csf) exit
-
    ! check the external orbital index: update n_orb if necessary
    n_orb = max(n_orb, maxval(csf_vec(n_occ:,icsf)))
+
+   ! if the returned coefficient is zero, we've read all csfs less than cutoff
+   if (icsf == n_csf) exit
 
   enddo read_csf_list
 


### PR DESCRIPTION
If the external orbital index of the last CSF was greater than all previous CSFs, the total number of orbitals would be truncated. Now the last update occurs before exiting the read_csf_list loop.